### PR TITLE
Allow define the Storage Class of the PVC used for the database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 
 - Allow define the Storage Class of the PVC used for the database
+- Start to use CRDs version v1 instead of v1beta1
+- Remove the support for k8s clusters < 1.16.0
 - Upgrade project to use version 0.18.1 of SDK
 - Update the title of the project in the CVS file
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+- Allow define the Storage Class of the PVC used for the database
 - Upgrade project to use version 0.18.1 of SDK
 - Update the title of the project in the CVS file
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
-- Upgrade project to use version 0.11.0 of SDK
+- Upgrade project to use version 0.18.1 of SDK
 - Update the title of the project in the CVS file
 
 ## [0.1.1] - 2019-09-09

--- a/deploy/crds/postgresql.dev4devs.com_databases_crd.yaml
+++ b/deploy/crds/postgresql.dev4devs.com_databases_crd.yaml
@@ -96,6 +96,11 @@ spec:
                   as well
                 format: int32
                 type: integer
+              databaseStorageClassName:
+                description: 'Name the Storage Class name of the PVC which will be
+                  created for the Database More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims
+                  Default value: slow'
+                type: string
               databaseStorageRequest:
                 description: 'Limit of Storage Request which will be available for
                   the database container Default value: 1Gi'

--- a/pkg/apis/postgresql/v1alpha1/database_types.go
+++ b/pkg/apis/postgresql/v1alpha1/database_types.go
@@ -117,6 +117,13 @@ type DatabaseSpec struct {
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.displayName="ConfigMap name"
 	ConfigMapName string `json:"configMapName,omitempty"`
 
+	// Name the Storage Class name of the PVC which will be created for the Database
+	// More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims
+	// Default value: slow
+	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
+	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.displayName="ConfigMap name"
+	DatabaseStorageClassName string `json:"databaseStorageClassName,omitempty"`
+
 	// Name of the configMap key where the operator should looking for the value for the database name for its env var
 	// Default value: nil
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true

--- a/pkg/config/database.go
+++ b/pkg/config/database.go
@@ -14,6 +14,7 @@ const (
 	databaseMemoryLimit       = "512Mi"
 	databaseMemoryRequest     = "128Mi"
 	databaseStorageRequest    = "1Gi"
+	databaseStorageClassName  = "slow"
 	databaseCpuLimit          = "60m"
 	databaseCpu               = "30m"
 )
@@ -34,6 +35,7 @@ type DefaultDatabaseConfig struct {
 	DatabaseCpuLimit          string `json:"databaseCpuLimit"`
 	DatabaseCpu               string `json:"databaseCpu"`
 	DatabaseStorageRequest    string `json:"databaseStorageRequest"`
+	DatabaseStorageClassName  string `json:"databaseStorageClassName"`
 }
 
 func NewDatabaseConfig() *DefaultDatabaseConfig {
@@ -53,5 +55,6 @@ func NewDatabaseConfig() *DefaultDatabaseConfig {
 		DatabaseCpu:               databaseCpu,
 		DatabaseCpuLimit:          databaseCpuLimit,
 		DatabaseStorageRequest:    databaseStorageRequest,
+		DatabaseStorageClassName:  databaseStorageClassName,
 	}
 }

--- a/pkg/resource/pvs.go
+++ b/pkg/resource/pvs.go
@@ -28,6 +28,7 @@ func NewDatabasePvc(db *v1alpha1.Database, scheme *runtime.Scheme) *corev1.Persi
 					corev1.ResourceStorage: resource.MustParse(db.Spec.DatabaseStorageRequest),
 				},
 			},
+			StorageClassName: &db.Spec.DatabaseStorageClassName,
 		},
 	}
 	controllerutil.SetControllerReference(db, pv, scheme)

--- a/pkg/utils/database_mandatory_specs.go
+++ b/pkg/utils/database_mandatory_specs.go
@@ -87,4 +87,8 @@ func AddDatabaseMandatorySpecs(db *v1alpha1.Database) {
 	if db.Spec.DatabasePort == 0 {
 		db.Spec.DatabasePort = defaulDatabaseConfig.DatabasePort
 	}
+
+	if len(db.Spec.DatabaseStorageClassName) < 1 {
+		db.Spec.DatabaseStorageClassName = defaulDatabaseConfig.DatabaseStorageClassName
+	}
 }


### PR DESCRIPTION
**Description**
- update the changelog to reflect the latest changes
- Allow define the Storage Class of the PVC used for the database

**Motivation**

Closes: #https://github.com/dev4devs-com/postgresql-operator/issues/69